### PR TITLE
Fix documentation issues from #147

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -6,8 +6,8 @@
 
 The github actions are run on every PR opened to main, as well as every push to main. They need to pass for a PR to be merge-able. 
 
-For the checks to pass, the code must be linted, all migrations must run successfully, and the [test suite](/helloworld/tests.py) must run
+For the checks to pass, the code must be linted, all migrations must run successfully, and the [test suite](https://github.com/cmciosu/hemp-db/blob/main/helloworld/tests.py) must run
 
 ## Vercel
 
-Vercel runs [build.sh](/build.sh) for the build step. For this to pass, just make sure all dependencies are listed in [requirements.txt](/requirements.txt) and all versions are correct.
+Vercel runs [build.sh](https://github.com/cmciosu/hemp-db/blob/main/build.sh) for the build step. For this to pass, just make sure all dependencies are listed in [requirements.txt](https://github.com/cmciosu/hemp-db/blob/main/requirements.txt) and all versions are correct.

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -31,8 +31,10 @@
   * For new env vars, add to .env, .env.example, and vercel
   * Make sure to add any new dependencies to requirements.txt
 
-3. Lint with `ruff check .`
-  * fix with `ruff check . --fix`
+3. Lint with ruff
+  * Access the running container's shell with `docker exec -it hempdb-dev /bin/bash` in a new terminal
+  * Lint with `ruff check .`
+  * Fix any errors with `ruff check . --fix`
 
 4. Open PR to dev
 

--- a/docs/FILES.md
+++ b/docs/FILES.md
@@ -4,15 +4,15 @@
 
 ## ~/hempdb
 
-Contains Django configuration files [settings.py](/hempdb/settings.py) and top-level urls [urls.py](/hempdb/urls.py) (auth URLs, homepage)
+Contains Django configuration files [settings.py](https://github.com/cmciosu/hemp-db/blob/main/hempdb/settings.py) and top-level urls [urls.py](https://github.com/cmciosu/hemp-db/blob/main/hempdb/urls.py) (auth URLs, homepage)
 
 ## ~/helloworld
 
 Contains the main Django application. Most of the logic is implemented in this folder. 
-- [urls.py](/helloworld/urls.py) contains all model routes, as well as routes to misc. pages. 
-- [views.py](/helloworld/views.py) contains all the View logic for all helloworld routes.
-- [models.py](/helloworld/models.py) contains our schema
-- [forms.py](/helloworld/forms.py) contains all model forms
+- [urls.py](https://github.com/cmciosu/hemp-db/blob/main/helloworld/urls.py) contains all model routes, as well as routes to misc. pages. 
+- [views.py](https://github.com/cmciosu/hemp-db/blob/main/helloworld/views.py) contains all the View logic for all helloworld routes.
+- [models.py](https://github.com/cmciosu/hemp-db/blob/main/helloworld/models.py) contains our schema
+- [forms.py](https://github.com/cmciosu/hemp-db/blob/main/helloworld/forms.py) contains all model forms
 ### /helloworld/templates
 
 All the template files used across the site. The registration subdirectory holds all template files related to auth

--- a/docs/INFRA.md
+++ b/docs/INFRA.md
@@ -10,7 +10,9 @@ Vercel automatically builds all branches pushed to github. Main branch is config
 
 ## CI
 
-We use Github Actions for CI. The only action used can be found in the [.github directory](/.github/workflows/migrate-test-lint.yml). It simply runs the test suite, migrations, and lints. This happens only on **opened pull requests to main** and **pushes to main**. 
+We use Github Actions for CI. The [migrate-test-lint workflow](https://github.com/cmciosu/hemp-db/blob/main/.github/workflows/migrate-test-lint.yml) runs the test suite, migrations, and lints. This happens on **opened pull requests to main** and **pushes to main**.
+
+The [codeql workflow](https://github.com/cmciosu/hemp-db/blob/main/.github/workflows/codeql.yml) performs a CodeQL analysis on the code. This happens on **opened pull requests to main**, **pushes to main**, and **weekly on main**.
 
 ## MySQL Database
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 - [Developing](DEVELOP.md)
 - [Build & CI/CD](BUILD.md)
 - [Infrastructure](INFRA.md)
-- [File Strcture](FILES.md)
+- [File Structure](FILES.md)
 - [DB Relations & Schema](MODELS.md)
 
 ## Documentation intended for End Users


### PR DESCRIPTION
Closes #147 with the following:
- Change file hyperlinks to reference github URLS to work with GitHub pages (I think relative file links only work when viewing MD in GitHub, not on GitHub pages once the MD is converted to HTML)
- Fix typo in index.md
- Add instruction to clarify ruff check step