### PR TITLE
Fix querying with wrong id in PendingChange

### DIFF
--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -348,9 +348,9 @@ def view_company_pending(request: HttpRequest, id: int) -> HttpResponse:
     """
     change = PendingChanges.objects.get(id=id)
     if change.changeType == 'deletion':
-        company = Company.objects.get(id = id)
+        company = Company.objects.get(id = change.companyId)
     if change.changeType == 'create' or change.changeType == 'edit':
-        company = PendingCompany.objects.select_related('Industry', 'Status', 'Grower').get(id = id)    
+        company = PendingCompany.objects.select_related('Industry', 'Status', 'Grower').get(id = change.companyId)    
     obj = model_to_dict(company)
     # Manually add FK values
     obj["Status"] = company.Status.status


### PR DESCRIPTION
### Properly query the Company table with the proper ID stored within the PendingChanges table.
- Current implementation attempts to query for a company using the PendingChanges object id, and not the companyID field.
- Can reproduce error by attempting to view a pending change's details on the [changes page](https://hempdb.vercel.app/changes/). 