### PR TITLE
Notify admins of pending changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 SECRET_KEY = key-here
 DATABASE_URL = mysql://<MYSQL_USER>:<MYSQL_PASS>@<MYSQL_HOST>/<MYSQL_NAME>
 SENTRY_DSN = dsn-here
+EMAIL_USER = from-email-here
+EMAIL_APP_PASSWORD = app-password-here

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 .env
 .ruff_cache
+*.sql

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 /mysql
-/helloworld/__pycache__
-/hempdb/__pycache__
-*/__pycache__
-*/migrations/__pycache__
+**/__pycache__/
 .DS_Store
 .env
 .ruff_cache

--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -6,18 +6,18 @@ from django.contrib.auth.models import User, Group
 
 def email_admins(action: str, company_name: str, pending_change_id: int) -> None:
     """
-    Sends an email notification to Admins and SrAdmins when a company has been created or edited.
+    Sends an email notification to Admins and SrAdmins when a company has been created, edited, or deleted.
 
     Note that if the company name is a part of the edit, the new name will appear in the email.
     
     Parameters:
-    action (str): Can only be 'created' or 'edited', depending on if the company is new or was just edited
+    action (str): Can only be 'created', 'edited', or 'deleted' depending on the action.
     company_name (str): Name of the company
     pending_change_id (int): ID of the pending change
     """
 
     # Invalid action
-    if action not in ['created', 'edited']:
+    if action not in ['created', 'edited', 'deleted']:
         return
 
     subject = f'[HempDB] Company {action} (Pending Review)'

--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -14,7 +14,7 @@ def notify_admins_pending_new_company(company_name: str, pending_change_id: int)
     
     Parameters:
     company_name (str): Name of the pending company
-    pending_change_id (int): ID of the pending company
+    pending_change_id (int): ID of the pending change
     """
 
     subject = '[HempDB] New Pending Company'
@@ -30,6 +30,51 @@ def notify_admins_pending_new_company(company_name: str, pending_change_id: int)
     # HTML (clickable links)
     html_message = f"""
     <p>A new company called "{company_name}" has been created and is now pending.</p>
+    
+    <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
+    <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>
+    """
+
+    # Group IDs from auth_group containing 'admin' (case insensitive)
+    admin_groups = Group.objects.filter(name__icontains='admin')
+    admin_group_ids = admin_groups.values_list('id', flat=True)
+
+    # Get list of emails for all users that are some form of admin
+    admin_emails = list(User.objects.filter(groups__id__in=admin_group_ids).values_list('email', flat=True).distinct())
+
+    send_mail(
+        subject=subject,
+        message=text_message,
+        from_email=None,    # Uses DEFAULT_FROM_EMAIL
+        html_message=html_message,
+        recipient_list=admin_emails,
+        fail_silently=True
+    )
+
+def notify_admins_pending_company_edit(company_name: str, pending_change_id: int) -> None:
+    """
+    Sends email notification to Admins and SrAdmins when a change to an existing company is made (pending)
+
+    If the company name is changed as part of the edit, the email will contain the new name.
+    
+    Parameters:
+    company_name (str): Name of the company changed
+    pending_change_id (int): ID of the pending change
+    """
+
+    subject = '[HempDB] New Pending Change'
+    
+    # Plaintext
+    text_message = f"""
+    A change to the company called "{company_name}" has been made and is now pending.
+    
+    View this pending change at: {settings.SITE_URL}/companies_pending/{pending_change_id}
+    View all pending changes at: {settings.SITE_URL}/changes
+    """
+
+    # HTML (clickable links)
+    html_message = f"""
+    <p>A change to the company called "{company_name}" has been made and is now pending.</p>
     
     <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
     <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>

--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -3,25 +3,28 @@ from django.conf import settings
 from django.contrib.auth.models import User, Group
 
 # Django Emails: https://docs.djangoproject.com/en/5.1/topics/email/
-"""
-Todo (In-Progress)
-- Create method to notify of a pending company edit, not pending new company
-- Create method for when # of pending changes meets a threshold
-"""
-def notify_admins_pending_new_company(company_name: str, pending_change_id: int) -> None:
+
+def email_admins(action: str, company_name: str, pending_change_id: int) -> None:
     """
-    Sends email notification to Admins and SrAdmins when a new company is created (pending)
+    Sends an email notification to Admins and SrAdmins when a company has been created or edited.
+
+    Note that if the company name is a part of the edit, the new name will appear in the email.
     
     Parameters:
-    company_name (str): Name of the pending company
+    action (str): Can only be 'created' or 'edited', depending on if the company is new or was just edited
+    company_name (str): Name of the company
     pending_change_id (int): ID of the pending change
     """
 
-    subject = '[HempDB] New Pending Company'
+    # Invalid action
+    if action not in ['created', 'edited']:
+        return
+
+    subject = f'[HempDB] Company {action} (Pending Review)'
     
     # Plaintext
     text_message = f"""
-    A new company called "{company_name}" has been created and is now pending.
+    A company called "{company_name}" has been {action} and is now pending review.
     
     View this pending change at: {settings.SITE_URL}/companies_pending/{pending_change_id}
     View all pending changes at: {settings.SITE_URL}/changes
@@ -29,52 +32,7 @@ def notify_admins_pending_new_company(company_name: str, pending_change_id: int)
 
     # HTML (clickable links)
     html_message = f"""
-    <p>A new company called "{company_name}" has been created and is now pending.</p>
-    
-    <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
-    <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>
-    """
-
-    # Group IDs from auth_group containing 'admin' (case insensitive)
-    admin_groups = Group.objects.filter(name__icontains='admin')
-    admin_group_ids = admin_groups.values_list('id', flat=True)
-
-    # Get list of emails for all users that are some form of admin
-    admin_emails = list(User.objects.filter(groups__id__in=admin_group_ids).values_list('email', flat=True).distinct())
-
-    send_mail(
-        subject=subject,
-        message=text_message,
-        from_email=None,    # Uses DEFAULT_FROM_EMAIL
-        html_message=html_message,
-        recipient_list=admin_emails,
-        fail_silently=True
-    )
-
-def notify_admins_pending_company_edit(company_name: str, pending_change_id: int) -> None:
-    """
-    Sends email notification to Admins and SrAdmins when a change to an existing company is made (pending)
-
-    If the company name is changed as part of the edit, the email will contain the new name.
-    
-    Parameters:
-    company_name (str): Name of the company changed
-    pending_change_id (int): ID of the pending change
-    """
-
-    subject = '[HempDB] New Pending Change'
-    
-    # Plaintext
-    text_message = f"""
-    A change to the company called "{company_name}" has been made and is now pending.
-    
-    View this pending change at: {settings.SITE_URL}/companies_pending/{pending_change_id}
-    View all pending changes at: {settings.SITE_URL}/changes
-    """
-
-    # HTML (clickable links)
-    html_message = f"""
-    <p>A change to the company called "{company_name}" has been made and is now pending.</p>
+    <p>A company called "{company_name}" has been {action} and is now pending review.</p>
     
     <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
     <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>

--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -1,0 +1,52 @@
+from django.core.mail import send_mail
+from django.conf import settings
+from django.contrib.auth.models import User, Group
+
+# Django Emails: https://docs.djangoproject.com/en/5.1/topics/email/
+"""
+Todo (In-Progress)
+- Create method to notify of a pending company edit, not pending new company
+- Create method for when # of pending changes meets a threshold
+"""
+def notify_admins_pending_new_company(company_name: str, pending_change_id: int) -> None:
+    """
+    Sends email notification to Admins and SrAdmins when a new company is created (pending)
+    
+    Parameters:
+    company_name (str): Name of the pending company
+    pending_change_id (int): ID of the pending company
+    """
+
+    subject = '[HempDB] New Pending Company'
+    
+    # Plaintext
+    text_message = f"""
+    A new company called "{company_name}" has been created and is now pending.
+    
+    View this pending change at: {settings.SITE_URL}/companies_pending/{pending_change_id}
+    View all pending changes at: {settings.SITE_URL}/changes
+    """
+
+    # HTML (clickable links)
+    html_message = f"""
+    <p>A new company called "{company_name}" has been created and is now pending.</p>
+    
+    <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
+    <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>
+    """
+
+    # Group IDs from auth_group containing 'admin' (case insensitive)
+    admin_groups = Group.objects.filter(name__icontains='admin')
+    admin_group_ids = admin_groups.values_list('id', flat=True)
+
+    # Get list of emails for all users that are some form of admin
+    admin_emails = list(User.objects.filter(groups__id__in=admin_group_ids).values_list('email', flat=True).distinct())
+
+    send_mail(
+        subject=subject,
+        message=text_message,
+        from_email=None,    # Uses DEFAULT_FROM_EMAIL
+        html_message=html_message,
+        recipient_list=admin_emails,
+        fail_silently=True
+    )

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -31,7 +31,7 @@ from .models import Industry
 from .models import Status
 from .models import Resources
 from .models import UploadIndex
-from .notifications import *
+from .notifications import notify_admins_pending_new_company, notify_admins_pending_company_edit
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
@@ -307,8 +307,8 @@ def edit_company(request: HttpRequest, id: int) -> HttpResponse:
                 setattr(new_company, field.name, getattr(company_edit, field.name))
         new_company.save()
         messages.info(request, 'Company successfully edited')
-        PendingChanges.objects.create(companyId=new_company.id, changeType='edit', editId=company.id)
-        # Todo: send company change email here
+        pending_change = PendingChanges.objects.create(companyId=new_company.id, changeType='edit', editId=company.id)
+        notify_admins_pending_company_edit(company_name=new_company.Name, pending_change_id=pending_change.id)
         return redirect('/companies')  # Redirect to a success page
     else: 
         form = PendingCompanyForm(instance=company)

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -31,7 +31,7 @@ from .models import Industry
 from .models import Status
 from .models import Resources
 from .models import UploadIndex
-from .notifications import notify_admins_pending_new_company, notify_admins_pending_company_edit
+from .notifications import email_admins
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
@@ -251,7 +251,7 @@ def companies(request: HttpRequest) -> HttpResponse:
             company = form.save()
             messages.info(request, 'Company successfully submitted')
             pending_change = PendingChanges.objects.create(companyId=company.id, changeType='create')
-            notify_admins_pending_new_company(company_name=company.Name, pending_change_id=pending_change.id)
+            email_admins(action='created', company_name=company.Name, pending_change_id=pending_change.id)
             return redirect('/companies')  # Redirect to a success page
     else:
         form = PendingCompanyForm()
@@ -308,7 +308,7 @@ def edit_company(request: HttpRequest, id: int) -> HttpResponse:
         new_company.save()
         messages.info(request, 'Company successfully edited')
         pending_change = PendingChanges.objects.create(companyId=new_company.id, changeType='edit', editId=company.id)
-        notify_admins_pending_company_edit(company_name=new_company.Name, pending_change_id=pending_change.id)
+        email_admins(action='edited', company_name=new_company.Name, pending_change_id=pending_change.id)
         return redirect('/companies')  # Redirect to a success page
     else: 
         form = PendingCompanyForm(instance=company)

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -509,8 +509,11 @@ def remove_companies(request: HttpRequest, id: int) -> HttpResponse:
     Returns:
     response (HttpResponse): HTTP response redirecting to /companies
     """
-    PendingChanges.objects.create(companyId=id, changeType='deletion')
+    company = Company.objects.get(id=id)
+    pending_change = PendingChanges.objects.create(companyId=id, changeType='deletion')
+
     messages.info(request, 'Deletion of Company requested')
+    email_admins(action='deleted', company_name=company.Name, pending_change_id=pending_change.id)
 
     return redirect('/companies')
 

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -160,11 +160,6 @@ sentry_sdk.init(
     profiles_sample_rate=1.0,
 )
 
-if DEBUG:
-    SITE_URL = "http://localhost:8000"
-else:
-    SITE_URL = "https://hempdb.vercel.app" # TODO: change after migration
-
 # Configuration for sending emails
 # https://docs.djangoproject.com/en/5.1/topics/email/
 EMAIL_HOST = 'smtp.gmail.com'
@@ -175,5 +170,7 @@ EMAIL_HOST_PASSWORD = os.getenv('EMAIL_APP_PASSWORD')
 
 if DEBUG: # Print emails to console instead of sending them
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+    SITE_URL = "http://localhost:8000"
 else:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    SITE_URL = "https://hempdb.vercel.app" # TODO: change after migration

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -159,3 +159,15 @@ sentry_sdk.init(
     # We recommend adjusting this value in production.
     profiles_sample_rate=1.0,
 )
+
+# Configuration for sending emails   
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = os.getenv('EMAIL_USER')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_APP_PASSWORD')
+
+if DEBUG: # Print emails to console instead of sending them
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -160,11 +160,17 @@ sentry_sdk.init(
     profiles_sample_rate=1.0,
 )
 
-# Configuration for sending emails   
+if DEBUG:
+    SITE_URL = "http://localhost:8000"
+else:
+    SITE_URL = "https://hempdb.vercel.app" # TODO: change after migration
+
+# Configuration for sending emails
+# https://docs.djangoproject.com/en/5.1/topics/email/
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = os.getenv('EMAIL_USER')
+EMAIL_HOST_USER = DEFAULT_FROM_EMAIL = os.getenv('EMAIL_USER')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_APP_PASSWORD')
 
 if DEBUG: # Print emails to console instead of sending them

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -173,4 +173,4 @@ if DEBUG: # Print emails to console instead of sending them
     SITE_URL = "http://localhost:8000"
 else:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    SITE_URL = "https://hempdb.vercel.app" # TODO: change after migration
+    SITE_URL = "https://hempdb.vercel.app" # TODO: change after infra migration


### PR DESCRIPTION
### Main Changes
- Anyone in a group containing "admin" (Admin and SrAdmin) will **receive an email when a pending change is created**. This occurs when someone edits, creates, or deletes a company. The emails look like this: 
![image](https://github.com/user-attachments/assets/54982339-e7ce-490c-8fc3-bd5e7a4b5689)
- This feature is intended to help with the ultimate goal of making the project more automated for administrators. Ideally this will also keep the database more active and up to date.

### Things to Note
- This feature requires that people are a part of the Admin or SrAdmin groups (this is **not currently the case** in production).
- In my testing, the first email I got was in my junk folder. You may need to look there and trust the sender.

### Miscellaneous Changes
- Condensed `.gitignore` to ignore all `__pycache__`
- Changed the companies search feature to be case-insensitive
- Added necessary environment variables to Vercel project

### Testing
- I have tested this locally and on the Vercel Deployment.
- To test this, you need to add your account to an admin group in the Django admin portal, and create, delete, or edit a company. Emails usually take a minute or two to send.
  - If you want to test locally, you will also need to add `EMAIL_USER` and `EMAIL_APP_PASSWORD` to your `.env` file.


