### PR TITLE
Fix various m2m bugs

### DIFF
--- a/helloworld/signals.py
+++ b/helloworld/signals.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User, Group
 # Any group which has the substring "admin" in the group name is considered a staff group
 @receiver(m2m_changed, sender=User.groups.through)
 def update_is_staff_on_group_change(sender, instance, action, reverse, model, pk_set, **kwargs):
-    # Ensure instance is User object to avoid bug when calling form.save_m2m when editing a Company
+    # Ensure instance is User object to avoid bug when changing m2m data of companies
     if not isinstance(instance, User):
         return
 

--- a/helloworld/signals.py
+++ b/helloworld/signals.py
@@ -12,6 +12,9 @@ from django.contrib.auth.models import User, Group
 # Any group which has the substring "admin" in the group name is considered a staff group
 @receiver(m2m_changed, sender=User.groups.through)
 def update_is_staff_on_group_change(sender, instance, action, reverse, model, pk_set, **kwargs):
+    # Ensure instance is User object to avoid bug when calling form.save_m2m when editing a Company
+    if not isinstance(instance, User):
+        return
 
     # Check if the action is 'post_add' (user was added to a group)
     # Enabled is_staff

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -524,12 +524,23 @@ def view_company_approve(_request: HttpRequest, id: int) -> HttpResponse:
             if not field.primary_key:
                 setattr(new_company, field.name, getattr(pendingCompany, field.name))
         new_company.save()
+
+        # Copy over m2m values
+        for field in pendingCompany._meta.many_to_many:
+            m2m_values = getattr(pendingCompany, field.name).all()
+            getattr(new_company, field.name).set(m2m_values)
+
     if change.changeType == 'edit':
         company = Company.objects.get(id = change.editId)
         for field in pendingCompany._meta.fields:
             if not field.primary_key:
                 setattr(company, field.name, getattr(pendingCompany, field.name))
         company.save()
+
+        # Copy over m2m values
+        for field in pendingCompany._meta.many_to_many:
+            m2m_values = getattr(pendingCompany, field.name).all()
+            getattr(company, field.name).set(m2m_values)
 
     change.delete()
     pendingCompany.delete()

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -386,6 +386,18 @@ def edit_company(request: HttpRequest, id: int) -> HttpResponse:
             new_company.Longitude = lng
 
         new_company.save()
+        
+        # Save the m2m values from the form to the PendingCompany instance (new_company)
+        # Note, using form.save_m2m doesn't work here
+        for field_name, field_value in form.cleaned_data.items():
+
+            # If the field is an M2M field
+            if field_name in [field.name for field in new_company._meta.many_to_many]:
+                # Get the M2M field from the new_company PendingCompany instance
+                m2m_field = getattr(new_company, field_name)
+                # Update it's value with updated value(s) from form
+                m2m_field.set(field_value)
+
         messages.info(request, 'Company successfully edited')
         pending_change = PendingChanges.objects.create(companyId=new_company.id, changeType='edit', editId=company.id)
         email_admins(action='edited', company_name=new_company.Name, pending_change_id=pending_change.id)

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -388,7 +388,6 @@ def edit_company(request: HttpRequest, id: int) -> HttpResponse:
         new_company.save()
         
         # Save the m2m values from the form to the PendingCompany instance (new_company)
-        # Note, using form.save_m2m doesn't work here
         for field_name, field_value in form.cleaned_data.items():
 
             # If the field is an M2M field


### PR DESCRIPTION
Solves #166 and more

m2m data: `solutions`, `categories`, `stakeholder groups`, `development stages`, `product groups` (appear with checkmarks on forms)

### Bugs
Previously, a user would create a company, and this company's m2m values would be in the PendingCompany object and thus the companies_pending view. However once this change was approved, none of the m2m values would transfer over to the actual Company object.

Similar behavior occurred when editing a company, but the m2m edits didn't appear in the PendingCompany object, let alone the Company once approved.

### Fixes
1. When editing a company, manually copy over all m2m data from the changed form to the new PendingCompany instance.
2. When approving a company creation or edit, do similar copying but from the PendingCompany to the new_company.
3. When messing this m2m data, sometimes the `update_is_staff_on_group_change` signal would get triggered. I added a check to ensure the instance is a User before executing this signal to prevent a server error (signal still works as intended).

### Testing
I tested the following behaviors locally connected to the dev database:
```
EDITING COMPANIES
Existing company with some m2m values checked. Edit company and check more.
Existing company with some checked. Remove all solutions check boxes but keep rest checked.
Existing company with some checked. Remove all solutions checked, check all categories checkboxes (prev none).
Remove all m2m checkmarks.
Various rejection behaviors look good.

CREATING COMPANIES
Create company with 1 of each m2m value checked.
Create company with none checked.
Create company with just 1 m2m value checked.
```