### PR TITLE
Add company map filters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DATABASE_URL = mysql://<MYSQL_USER>:<MYSQL_PASS>@<MYSQL_HOST>/<MYSQL_NAME>
 SENTRY_DSN = dsn-here
 EMAIL_USER = from-email-here
 EMAIL_APP_PASSWORD = app-password-here
+REDIS_URL = redis://<user>:<password>@<url>:<port>

--- a/.github/workflows/migrate-test-lint.yml
+++ b/.github/workflows/migrate-test-lint.yml
@@ -32,12 +32,14 @@ jobs:
       env:
         DATABASE_URL: ${{ secrets.DATABASE_URL }}
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        REDIS_URL: ${{ secrets.REDIS_URL }}
     - name: Run Tests
       run: |
         python manage.py test
       env:
         DATABASE_URL: ${{ secrets.DATABASE_URL }}
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        REDIS_URL: ${{ secrets.REDIS_URL }}
     - name: Lint
       run: |
         ruff check .

--- a/helloworld/templates/map.html
+++ b/helloworld/templates/map.html
@@ -55,7 +55,7 @@
     // Extract data from json_script template filter above to embed in HTML
     const companies = JSON.parse(document.getElementById('company_data').textContent);
     const filterData = JSON.parse(document.getElementById('filter_data').textContent);
-
+    
     // Generates filters for sidebar from backend data
     function generateFilters() {
       let filtersDiv = document.getElementById('filters');
@@ -106,7 +106,6 @@
           ).map(checkbox => parseInt(checkbox.value));
         }
       });
-      console.log(selected)
       return selected;
     }
 

--- a/helloworld/templates/map.html
+++ b/helloworld/templates/map.html
@@ -7,70 +7,187 @@
 {% block content %}
 
   {{ companies|json_script:"company_data"}}
+  {{ filters|json_script:"filter_data" }}
 
-  <div id="map" style="height: 700px;"></div>
+  <div style="display: flex;">
+    <div id="map" style="height: 85vh; width: 75%;"></div>
+    <div id="sidebar" style="height: 85vh; width: 25%; display: flex; flex-direction: column;">
+      <div id="filter-heading" style="padding: 10px; border-bottom: 1px solid #dddddd;">
+        <div style="display: flex; justify-content: space-between;">
+          <h4 style="margin: 0px;">Company Filters</h4>
+          <div>
+            <button id="applyButton" class="btn btn-primary btn-sm">Apply</button>
+            <button id="resetButton" class="btn btn-secondary btn-sm">Reset</button>
+          </div>
+        </div>
+        <div id="companyCount" style="font-size: 12px; color: #777777;"></div>
+      </div>
+      <div id="filters" style="overflow-y: auto; padding: 10px;"></div>
+    </div>
+  </div>
+
   <script>
-    
     // Create standard and satellite base layers
-    var osmStandard = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    let osmStandard = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 16,
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors<br>'
     });
-    var usgsSatellite = L.tileLayer('https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}', {
+    let usgsSatellite = L.tileLayer('https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}', {
       maxZoom: 16,
 	    attribution: 'Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>'
     });
 
     // Create Leaflet map
-    var map = L.map('map', {
+    let map = L.map('map', {
       center: [39.833, -98.583],
       zoom: 4,
       layers: [osmStandard] // Default base layer
     });
 
     // Add base layer titles/layers to obj and add to map
-    var baseMaps = {
+    let baseMaps = {
       "OSM Standard": osmStandard,
       "USGA Satellite": usgsSatellite
     };
-    var layerControl = L.control.layers(baseMaps).addTo(map);
+    let layerControl = L.control.layers(baseMaps).addTo(map);
+    let markers = L.markerClusterGroup(); // Heatmap cluster
 
+    // Extract data from json_script template filter above to embed in HTML
+    const companies = JSON.parse(document.getElementById('company_data').textContent);
+    const filterData = JSON.parse(document.getElementById('filter_data').textContent);
 
-    // Add custom text instructions to the top-left corner
-    const customText = L.control({ position: 'topleft' });
+    // Generates filters for sidebar from backend data
+    function generateFilters() {
+      let filtersDiv = document.getElementById('filters');
+
+      filterData.forEach((filter, index) => {
+        // Create category heading
+        let category = document.createElement('h5');
+        category.textContent = filter.name;
+        if (index !== 0) category.style.marginTop = '12px';
+        filtersDiv.appendChild(category);
+
+        // Create checkboxes/radios for each category
+        filter.options.forEach(option => {
+          let div = document.createElement('div');
+          div.className = 'form-check'
+
+          let input = document.createElement('input');
+          input.type = filter.name === 'Industry' ? 'radio' : 'checkbox';
+          input.value = option.id;
+          input.name = filter.name;
+          input.id = `${filter.name}_${option.id}`;
+          input.className = 'form-check-input'
+
+          let label = document.createElement('label');
+          label.htmlFor = input.id;
+          label.textContent = option.name;
+          label.className = 'form-check-label'
+
+          div.appendChild(input);
+          div.appendChild(label);
+          filtersDiv.appendChild(div);
+        });
+      });
+    }
+
+    // Collect and return selected filters
+    function getSelectedFilters() {
+      // JSON of name-array pairs. Arrays are list of ids of options selected for each category
+      let selected = {};
+      
+      filterData.forEach(filter => {
+        if (filter.name === 'Industry') { // Filter Industry radio buttons
+          let industryRadio = document.querySelector(`input[name="${filter.name}"]:checked`);
+          selected[filter.name] = industryRadio ? [parseInt(industryRadio.value)] : [];
+        } else {
+          selected[filter.name] = Array.from( // Filter checkboxes
+              document.querySelectorAll(`input[name="${filter.name}"]:checked`)
+          ).map(checkbox => parseInt(checkbox.value));
+        }
+      });
+      console.log(selected)
+      return selected;
+    }
+
+    // Places markers on map based on selected filters or upon page load
+    function addMarkers() {
+      markers.clearLayers();
+      let selectedFilters = getSelectedFilters();
+      let numMarkers = 0;
+
+      companies.forEach(company => {
+        let shouldDisplay = true;
+
+        // Loop over each category like Industry, Stages, etc.
+        // Example of selectedFilters entry: stages: [1, 2, 5]
+        for (let [category, selectedIds] of Object.entries(selectedFilters)) {
+          if (selectedIds.length === 0) continue;
+
+          let companyIds = company[category];
+          if (category === 'Industry') {
+            if (!companyIds || !selectedIds.includes(companyIds)) {
+              shouldDisplay = false;
+              break;
+            }
+          } else {
+              let companyIdsClean = companyIds || []; // Ensure array type. M2Ms may be empty unlike FK
+              if (!selectedIds.every(id => companyIdsClean.includes(id))) {
+                shouldDisplay = false;
+                break;
+              }
+          }
+        }
+
+        // Place marker if company should be displayed
+        if (shouldDisplay) {
+          let marker = L.marker([company.Latitude, company.Longitude], {
+            title: company.Name
+          });
+
+          let popupContent = `<b><a href="/companies/${company.id}" target="_blank">${company.Name}</a></b><br>`;
+          popupContent += `Location: ${company.Location}<br>`;
+          if (company.Phone) popupContent += `Phone: ${company.Phone}<br>`;
+          if (company.Website) popupContent += `Website: <a href="${company.Website}" target="_blank">${company.Website}</a>`;
+
+          marker.bindPopup(popupContent);
+          markers.addLayer(marker);
+          numMarkers++;
+        }
+      });
+
+      map.addLayer(markers);
+      updateCompanyCount(numMarkers);
+    }
+    
+    // Uncheck all boxes/radios and redisplay all markers
+    function resetFilters() {
+      document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(input => {
+        input.checked = false;
+      });
+      addMarkers();
+    }
+
+    // Update the company count text
+    function updateCompanyCount(count) {
+      let companyCountDiv = document.getElementById('companyCount');
+      companyCountDiv.textContent = `${count} Active Companies Shown`;
+    }
+
+    // Add custom text instructions bottom left of map
+    let customText = L.control({ position: 'bottomleft' });
     customText.onAdd = () => {
-        const p = L.DomUtil.create('p');
-        p.innerHTML = `Marker locations may be inaccurate.<br> 
-                      Click markers for up to date locations.`;
-        return p;
+      let p = L.DomUtil.create('p');
+      p.innerHTML = `Marker locations may be inaccurate.<br> 
+                    Click markers for up to date locations.`;
+      return p;
     };
     customText.addTo(map);
 
-    // Extract company data from json_script template filter above
-    const companies = JSON.parse(document.getElementById('company_data').textContent);
-
-    // Create marker cluster group and add marker for each company
-    var markers = L.markerClusterGroup();
-
-    companies.forEach(company => {
-      var marker = L.marker([company.Latitude, company.Longitude], {
-        title: company.Name // Hover value
-      });
-
-      // Create popup content for clicking markers
-      var popupContent = `<b><a href="https://hempdb.vercel.app/companies/${company.id}">${company.Name}</a></b><br>
-                          Location: ${company.Location}<br>`;
-      if (company.Phone) { 
-        popupContent += `Phone: ${company.Phone}<br>`;
-      }
-      if (company.Website) { 
-        popupContent += `Website: <a href="${company.Website}" target="_blank">${company.Website}</a><br>`;
-      }
-      marker.bindPopup(popupContent);
-      markers.addLayer(marker);
-    });
-
-    // Add the cluster group to the map
-    map.addLayer(markers);
+    // Init DOM
+    document.getElementById('applyButton').addEventListener('click', addMarkers);
+    document.getElementById('resetButton').addEventListener('click', resetFilters);
+    generateFilters();
+    addMarkers();
   </script>
 {% endblock %}

--- a/helloworld/templates/navbar.html
+++ b/helloworld/templates/navbar.html
@@ -40,10 +40,10 @@
             {% endif %}
           </div>
         </li>
+        {% endif %}
         <li class="nav-item">
           <a class="nav-link link-light px-3 text-light" href="/map">Map</a>
         </li>
-        {% endif %}
         {% if user.is_staff %}
           <li class="nav-item">
             <a class="nav-link link-light px-3 text-light" href="/changes">Changes</a>

--- a/helloworld/views.py
+++ b/helloworld/views.py
@@ -1343,7 +1343,7 @@ def map(request: HttpRequest) -> HttpResponse:
             'Phone': company.Phone if is_valid(company.Phone) else None,
             'Latitude': float(company.Latitude),
             'Longitude': float(company.Longitude),
-            'Location': ', '.join([l for l in [company.Address, company.City, company.State, company.Country] if is_valid(l)]),
+            'Location': ', '.join([i for i in [company.Address, company.City, company.State, company.Country] if is_valid(i)]),
             'Industry': company.Industry.id,
             'Categories': [c.id for c in company.Category.all()],
             'Stakeholder Group': [sg.id for sg in company.stakeholderGroup.all()],

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -176,3 +176,10 @@ if DEBUG: # Print emails to console instead of sending them
 else:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     SITE_URL = "https://hempdb.vercel.app" # TODO: change after infra migration
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": os.getenv('REDIS_URL'),
+    }
+}

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -177,9 +177,10 @@ else:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     SITE_URL = "https://hempdb.vercel.app" # TODO: change after infra migration
 
+REDIS_URL = os.getenv('REDIS_URL').strip()
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": os.getenv('REDIS_URL'),
+        "LOCATION": REDIS_URL,
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-bootstrap-v5==1.0.11
 django-crispy-forms==2.1
 djangorestframework==3.15.1
 geocoder==1.38.1
+hiredis==3.1.0
 numpy==1.26.4
 pandas==2.2.3
 pycparser==2.22
@@ -18,6 +19,7 @@ pyOpenSSL==24.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 pytz==2024.1
+redis==5.2.1
 ruff==0.4.5
 sentry-sdk==2.3.1
 six==1.16.0


### PR DESCRIPTION
Continuing #145
- Added ability to filter the map by Industry, Categories, Stakeholder Groups, Stages, and Product Groups
- Anyone can now see the map link on the homepage (don't have to be logged in)
- Added caching of data required to render map.html using Redis
- Added cache invalidation signal when applicable models are created, edited, or deleted