### PR TITLE
Split workflow to work with staging DB

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,11 @@
-name: Django CI
+name: Django Deploy to Prod
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:
-  build:
+  deploy:
 
     runs-on: ubuntu-latest
     strategy:
@@ -23,20 +23,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run Migrations (CI DB)
+    - name: Run Production Migrations
       run: |
         python manage.py migrate --noinput
       env:
-        DATABASE_URL: ${{ secrets.CI_STAGING_DATABASE_URL }}
+        DATABASE_URL: ${{ secrets.DATABASE_URL }}
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
         REDIS_URL: ${{ secrets.REDIS_URL }}
-    - name: Run Tests
-      run: |
-        python manage.py test
-      env:
-        DATABASE_URL: ${{ secrets.CI_STAGING_DATABASE_URL }}
-        SECRET_KEY: ${{ secrets.SECRET_KEY }}
-        REDIS_URL: ${{ secrets.REDIS_URL }}
-    - name: Lint
-      run: |
-        ruff check .


### PR DESCRIPTION
### Split workflow to work with staging DB
- on PR w/ main, perform migration to staging DB
- Avoids migrating prod DB before code changes can be merged to prevent crashing prod
- on push w/ main, perform migration to prod