### PR TITLE
Configure Admin Emails

### DIFF
--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -18,7 +18,7 @@ def email_admins(action: str, company_name: str, pending_change_id: int, request
     """
 
     # If DEBUG is True, this email will be logged to the console, NOT sent (settings.py)
-    if settings.DEBUG == False:                         # Email will be sent
+    if not settings.DEBUG:                              # Email will be sent
         if settings.PRODUCTION_URL not in request_host: # Request wansn't made from prod
             return                                      # Don't send email
 

--- a/helloworld/notifications.py
+++ b/helloworld/notifications.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User, Group
 
 # Django Emails: https://docs.djangoproject.com/en/5.1/topics/email/
 
-def email_admins(action: str, company_name: str, pending_change_id: int) -> None:
+def email_admins(action: str, company_name: str, pending_change_id: int, request_host: str) -> None:
     """
     Sends an email notification to Admins and SrAdmins when a company has been created, edited, or deleted.
 
@@ -14,7 +14,13 @@ def email_admins(action: str, company_name: str, pending_change_id: int) -> None
     action (str): Can only be 'created', 'edited', or 'deleted' depending on the action.
     company_name (str): Name of the company
     pending_change_id (int): ID of the pending change
+    request_host (str): the host that made the request (e.g. 'hempdb.vercel.app')
     """
+
+    # If DEBUG is True, this email will be logged to the console, NOT sent (settings.py)
+    if settings.DEBUG == False:                         # Email will be sent
+        if settings.PRODUCTION_URL not in request_host: # Request wansn't made from prod
+            return                                      # Don't send email
 
     # Invalid action
     if action not in ['created', 'edited', 'deleted']:
@@ -26,20 +32,14 @@ def email_admins(action: str, company_name: str, pending_change_id: int) -> None
     text_message = f"""
     A company called "{company_name}" has been {action} and is now pending review.
     
-    View this pending change at: {settings.SITE_URL}/companies_pending/{pending_change_id}
-    View all pending changes at: {settings.SITE_URL}/changes
-    
-    Please disregard this email if the above links don't work or if they send you to a site other than "hempdb.vercel.app". We apologize for any inconveniences.
+    View pending changes at: {settings.EMAIL_LINK}/changes
     """
 
     # HTML (clickable links)
     html_message = f"""
     <p>A company called "{company_name}" has been {action} and is now pending review.</p>
     
-    <p>View this pending change <a href="{settings.SITE_URL}/companies_pending/{pending_change_id}">here</a>.</p>
-    <p>View all pending changes <a href="{settings.SITE_URL}/changes">here</a>.</p>
-    
-    <p>Please disregard this email if the above links don't work or if they send you to a site other than "hempdb.vercel.app". We apologize for any inconveniences.</p>
+    <p>View pending changes <a href="{settings.EMAIL_LINK}/changes">here</a>.</p>
     """
 
     # Group IDs from auth_group containing 'admin' (case insensitive)

--- a/hempdb/settings.py
+++ b/hempdb/settings.py
@@ -16,6 +16,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.getenv('SECRET_KEY'))
 DEBUG = False
 
 ALLOWED_HOSTS = ['*']
+PRODUCTION_URL = 'hempdb.vercel.app'  # TODO: change after infra migration
 
 # For fetching datetime fields
 USE_TZ = True       # Make datetime objects timezone-aware
@@ -180,10 +181,10 @@ EMAIL_HOST_PASSWORD = os.getenv('EMAIL_APP_PASSWORD')
 
 if DEBUG: # Print emails to console instead of sending them
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-    SITE_URL = "http://localhost:8000"
+    EMAIL_LINK = "http://localhost:8000"
 else:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    SITE_URL = "https://hempdb.vercel.app" # TODO: change after infra migration
+    EMAIL_LINK = f"https://{PRODUCTION_URL}"
 
 REDIS_URL = os.getenv('REDIS_URL').strip()
 CACHES = {


### PR DESCRIPTION
1. Emails will now only be sent in a production environment
    - Occasionally developers would have `DEBUG` set to `False` locally or would be using a Vercel deployment (`DEBUG` also `False`), and would edit/create/delete a company. This would send an email to admins of HempDB.
    - This PR should eliminate that by checking the request host

2. Condense email messages themselves
    - I've removed the hyperlink to the specific change itself because with recent changes in #199 allowing people to view changes even if they've been approved or rejected, it looks like they still show the `Approve` and `Reject` buttons at the top. I've created Issue #202 for this, but in the meantime I think the hyperlink to the specific change should be removed
    - I've also removed the warning from the email as what it describes should no longer happen with these changes.